### PR TITLE
Fix minor spelling error

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -53,7 +53,7 @@
         that a lot of features simply don't make sense in the context of braille. Also, for the sake
         of simplicity, the authors didn't bother to include features that are not supported by
         implementations. Still it was chosen not to write the specification from scratch but to
-        explicitely reference existing specifications whenever possible and to explain the
+        explicitly reference existing specifications whenever possible and to explain the
         differences.
       </p>
       <p>
@@ -141,7 +141,7 @@
       <p>
         Value types, properties, functions and at-rules not defined in this specification are
         defined in CSS Level 2 Revision 1 [[CSS2]] or in other CSS modules. External definitions
-        will always be explicitely referenced from this specification. This specification will
+        will always be explicitly referenced from this specification. This specification will
         further expand, restrict or override definitions. In that case the differences will be
         explained in informative notes.
       </p>

--- a/src/main/generated_content.html
+++ b/src/main/generated_content.html
@@ -317,7 +317,7 @@
       <p>
         A <span class="css-propval">page</span> counter is created automatically on the root
         element. Its purpose is for numbering braille pages. The counter is implicitely incremented
-        on each page. Depending on the implementation, explicitely setting or incrementing this
+        on each page. Depending on the implementation, explicitly setting or incrementing this
         counter may or may not have an effect. No new counters can be created with the name <span
         class="css-propval">page</span>.
       </p>


### PR DESCRIPTION
This PR addresses the three occurrences of misspelling "explicitly" as "explicitely" in the project.